### PR TITLE
ED-171/feat: Add ip replacement restriction

### DIFF
--- a/proto/context_v1.thrift
+++ b/proto/context_v1.thrift
@@ -30,6 +30,7 @@ struct ContextFragment {
     5: optional Requester requester
 
     6: optional ContextCommonAPI capi
+   16: optional ContextCommonAPIPCIDSS capi_pcidss
     7: optional ContextOrgManagement orgmgmt
     8: optional ContextUrlShortener shortener
     9: optional ContextBinapi binapi
@@ -133,7 +134,6 @@ struct OrgRoleScope {
  */
 struct Requester {
     1: optional string ip
-    2: optional string replacement_ip
 }
 
 /**
@@ -255,6 +255,15 @@ struct CommonAPIOperation {
     13: optional Entity webhook
     14: optional Entity claim
     15: optional Entity payout
+}
+
+
+struct ContextCommonAPIPCIDSS {
+    1: optional ContextCommonAPIPCIDSS op
+}
+
+struct ContextCommonAPIPCIDSSOperation {
+    1: optional string replacement_ip
 }
 
 /**

--- a/proto/context_v1.thrift
+++ b/proto/context_v1.thrift
@@ -30,7 +30,6 @@ struct ContextFragment {
     5: optional Requester requester
 
     6: optional ContextCommonAPI capi
-   16: optional ContextCommonAPIPCIDSS capi_pcidss
     7: optional ContextOrgManagement orgmgmt
     8: optional ContextUrlShortener shortener
     9: optional ContextBinapi binapi
@@ -41,6 +40,8 @@ struct ContextFragment {
    13: optional ContextWebhooks webhooks
    14: optional ContextReports reports
    15: optional ContextClaimManagement claimmgmt
+   16: optional ContextTokens tokens
+
 }
 
 /**
@@ -258,11 +259,7 @@ struct CommonAPIOperation {
 }
 
 
-struct ContextCommonAPIPCIDSS {
-    1: optional ContextCommonAPIPCIDSS op
-}
-
-struct ContextCommonAPIPCIDSSOperation {
+struct ContextTokens {
     1: optional string replacement_ip
 }
 

--- a/proto/restriction.thrift
+++ b/proto/restriction.thrift
@@ -13,6 +13,7 @@ const Version HEAD = 1
 struct Restrictions {
     1: required Version vsn = HEAD
     2: optional RestrictionsAnalyticsAPI anapi
+    3: optional RestrictionsCommonAPI capi
 }
 
 /**
@@ -24,6 +25,13 @@ struct RestrictionsAnalyticsAPI {
 
 struct AnalyticsAPIOperationRestrictions {
     1: required set<Entity> shops
+}
+
+/**
+ * Ограничения, накладываемые на сервисы общего АПИ
+ */
+struct RestrictionsCommonAPI {
+    1: optional bool ip_replacement_forbidden
 }
 
 /**


### PR DESCRIPTION
На данный момент в случае отсутствия разрешения на подмену IP `capi_v2_pcidss` фоллбэчиться на IP запрашивающего, а не падает полностью. 

Добавляя ограничение на подмену возможно реализовать такой сценарий уже с `bouncer`.

Also see: #24